### PR TITLE
Fix: make mobile carousel show proper "previous" and "next" tags

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1530,6 +1530,13 @@ body.mobile-nav-active #mobile-nav-toggle {
   #schedule .nav-tabs a {
     padding: 8px 60px;
   }
+
+  .owl-nav {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+  }
+
 }
 
 @media (max-width: 768px) {

--- a/js/main.js
+++ b/js/main.js
@@ -126,8 +126,9 @@ jQuery(document).ready(function( $ ) {
   // Carrusel de fotos con .owlCarousel
   $(".gallery-carousel").owlCarousel({
     loop: true,
-    nav: true,
+    nav: true,    
     dots: true,
+    navText: ["Anterior", "Siguiente"],
     autoplay: true,
     autoplayHoverPause:true,
     responsiveClass:true,


### PR DESCRIPTION
Arreglé las tags de cambio de carrusel en móvil y tablet para mostrar "Anterior" y "Siguiente" en lugar de "prev" y "next". Además, ahora están apropiadamente alineados de forma horizontal en lugar de uno encima del otro. 

Tengo incertidumbre acerca del uso del ID "#gallery" en el archivo de CSS cuando no se ha implementado en el HTML, ya que este tiene varios estilos ya hechos 🤔. ¿Se planea implementarlo de nuevo en algún punto? 